### PR TITLE
Allow writing registers larger than one byte

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
-authors = ["Broderick Carlin"]
-categories = ["embedded", "no-std", "hardware-support"]
+authors = [ "Broderick Carlin" ]
+categories = [
+  "embedded",
+  "no-std",
+  "hardware-support"
+]
 description = "Rust embedded-hal driver for the A7105 2.4GHz FSK/GFSK Transceiver"
 edition = "2021"
-keywords = ["a7105", "no-std", "gfsk", "afhds", "embedded-hal"]
+keywords = [ "a7105", "no-std", "gfsk", "afhds", "embedded-hal" ]
 license = "MIT OR Apache-2.0"
 name = "a7105"
 readme = "README.md"
@@ -21,5 +25,5 @@ embedded-hal-mock = { version = "0.10", features = ["eh1"] }
 
 [features]
 default = ["async"]
-async = ["embedded-hal-async"]
+async = ["embedded-hal-async"] 
 blocking = ["embedded-hal", "maybe-async/is_sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,9 @@
 [package]
-authors = [ "Broderick Carlin" ]
-categories = [
-  "embedded",
-  "no-std",
-  "hardware-support"
-]
+authors = ["Broderick Carlin"]
+categories = ["embedded", "no-std", "hardware-support"]
 description = "Rust embedded-hal driver for the A7105 2.4GHz FSK/GFSK Transceiver"
 edition = "2021"
-keywords = [ "a7105", "no-std", "gfsk", "afhds", "embedded-hal" ]
+keywords = ["a7105", "no-std", "gfsk", "afhds", "embedded-hal"]
 license = "MIT OR Apache-2.0"
 name = "a7105"
 readme = "README.md"
@@ -20,7 +16,10 @@ embedded-hal = { version = "1.0.0-rc.1", optional = true }
 embedded-hal-async = { version = "1.0.0-rc.1", optional = true }
 maybe-async = "0.2"
 
+[dev-dependencies]
+embedded-hal-mock = { version = "0.10", features = ["eh1"] }
+
 [features]
 default = ["async"]
-async = ["embedded-hal-async"] 
+async = ["embedded-hal-async"]
 blocking = ["embedded-hal", "maybe-async/is_sync"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,61 +196,7 @@ mod test {
     use registers::{DataRate, IdData};
 
     #[test]
-    fn reset_command() {
-        let expectations = [
-            SpiTransaction::transaction_start(),
-            SpiTransaction::write_vec(vec![0, 0]),
-            SpiTransaction::transaction_end(),
-        ];
-
-        let spi = SpiMock::new(&expectations);
-
-        let mut radio = A7105::new(spi);
-
-        radio.command(Command::Reset).unwrap();
-
-        radio.spi.done();
-    }
-
-    #[test]
-    fn read_id_reg() {
-        let expectations = [
-            SpiTransaction::transaction_start(),
-            SpiTransaction::write(0x46),
-            SpiTransaction::read_vec(vec![0x67, 0x45, 0x23, 0x01]),
-            SpiTransaction::transaction_end(),
-        ];
-
-        let spi = SpiMock::new(&expectations);
-
-        let mut radio = A7105::new(spi);
-
-        let id_data: IdData = radio.read_reg().unwrap();
-
-        assert_eq!(IdData { id: 0x01234567 }, id_data);
-        radio.spi.done();
-    }
-
-    #[test]
-    fn write_id_reg() {
-        let expectations = [
-            SpiTransaction::transaction_start(),
-            SpiTransaction::write(0x06),
-            SpiTransaction::write_vec(vec![0x67, 0x45, 0x23, 0x01]),
-            SpiTransaction::transaction_end(),
-        ];
-
-        let spi = SpiMock::new(&expectations);
-
-        let mut radio = A7105::new(spi);
-
-        radio.write_reg(IdData { id: 0x01234567 }).unwrap();
-
-        radio.spi.done();
-    }
-
-    #[test]
-    fn read_data_rate_reg() {
+    fn read_single_byte_reg() {
         let expectations = [
             SpiTransaction::transaction_start(),
             SpiTransaction::write(0x4E),
@@ -269,7 +215,7 @@ mod test {
     }
 
     #[test]
-    fn write_data_rate_reg() {
+    fn writed_single_byte_reg() {
         let expectations = [
             SpiTransaction::transaction_start(),
             SpiTransaction::write(0x0E),
@@ -282,6 +228,43 @@ mod test {
         let mut radio = A7105::new(spi);
 
         radio.write_reg(DataRate { rate: 0x20 }).unwrap();
+
+        radio.spi.done();
+    }
+
+    #[test]
+    fn read_multiple_byte_reg() {
+        let expectations = [
+            SpiTransaction::transaction_start(),
+            SpiTransaction::write(0x46),
+            SpiTransaction::read_vec(vec![0x67, 0x45, 0x23, 0x01]),
+            SpiTransaction::transaction_end(),
+        ];
+
+        let spi = SpiMock::new(&expectations);
+
+        let mut radio = A7105::new(spi);
+
+        let id_data: IdData = radio.read_reg().unwrap();
+
+        assert_eq!(IdData { id: 0x01234567 }, id_data);
+        radio.spi.done();
+    }
+
+    #[test]
+    fn write_multiple_byte_reg() {
+        let expectations = [
+            SpiTransaction::transaction_start(),
+            SpiTransaction::write(0x06),
+            SpiTransaction::write_vec(vec![0x67, 0x45, 0x23, 0x01]),
+            SpiTransaction::transaction_end(),
+        ];
+
+        let spi = SpiMock::new(&expectations);
+
+        let mut radio = A7105::new(spi);
+
+        radio.write_reg(IdData { id: 0x01234567 }).unwrap();
 
         radio.spi.done();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 //! `a7105` is a Rust crate that provides a high-level interface for interacting
 //! with the A7105 2.4GHz FSK/GFSK Transceiver, built on top of
@@ -182,5 +182,29 @@ impl<SPI: SpiDevice> A7105<SPI> {
                 Operation::Write(buf),
             ])
             .await
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "blocking")]
+mod test {
+    use super::*;
+    use embedded_hal_mock::eh1::spi::{Mock as SpiMock, Transaction as SpiTransaction};
+
+    #[test]
+    fn reset_command() {
+        let expectations = [
+            SpiTransaction::transaction_start(),
+            SpiTransaction::write_vec(vec![0, 0]),
+            SpiTransaction::transaction_end(),
+        ];
+
+        let spi = SpiMock::new(&expectations);
+
+        let mut radio = A7105::new(spi);
+
+        radio.command(Command::Reset).unwrap();
+
+        radio.spi.done();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ impl<SPI: SpiDevice> A7105<SPI> {
 mod test {
     use super::*;
     use embedded_hal_mock::eh1::spi::{Mock as SpiMock, Transaction as SpiTransaction};
-    use registers::IdData;
+    use registers::{DataRate, IdData};
 
     #[test]
     fn reset_command() {
@@ -225,6 +225,43 @@ mod test {
         let id_data: IdData = radio.read_reg().unwrap();
 
         assert_eq!(IdData { id: 0x01234567 }, id_data);
+        radio.spi.done();
+    }
+
+    #[test]
+    fn read_data_rate_reg() {
+        let expectations = [
+            SpiTransaction::transaction_start(),
+            SpiTransaction::write(0x4E),
+            SpiTransaction::read(0x20),
+            SpiTransaction::transaction_end(),
+        ];
+
+        let spi = SpiMock::new(&expectations);
+
+        let mut radio = A7105::new(spi);
+
+        let data_rate: DataRate = radio.read_reg().unwrap();
+
+        assert_eq!(DataRate { rate: 0x20 }, data_rate);
+        radio.spi.done();
+    }
+
+    #[test]
+    fn write_data_rate_reg() {
+        let expectations = [
+            SpiTransaction::transaction_start(),
+            SpiTransaction::write(0x0E),
+            SpiTransaction::write(0x20),
+            SpiTransaction::transaction_end(),
+        ];
+
+        let spi = SpiMock::new(&expectations);
+
+        let mut radio = A7105::new(spi);
+
+        radio.write_reg(DataRate { rate: 0x20 }).unwrap();
+
         radio.spi.done();
     }
 }


### PR DESCRIPTION
Fixes #12

I have added some tests for reading and writing registers using embedded-hal-mock. I could only get the blocking version compiling though.

I have changed `write_reg` to add back in support for writing registers larger than one byte like the id data reg.